### PR TITLE
CODE RUB: Comparing data is redundant if key not found

### DIFF
--- a/Xeption/Xeption.cs
+++ b/Xeption/Xeption.cs
@@ -62,11 +62,16 @@ namespace Xeptions
             {
                 bool isKeyNotExists = this.Data.Contains(entry.Key) is false;
 
+                if (isKeyNotExists)
+                {
+                    return false;
+                }
+
                 bool isDataNotSame = CompareData(
                     firstObject: this.Data[entry.Key],
                     secondObject: dictionary[entry.Key]);
 
-                if (isKeyNotExists || isDataNotSame)
+                if (isDataNotSame)
                 {
                     return false;
                 }


### PR DESCRIPTION
Didn't test it, but a dictionary is supposed to throw an exception when trying to access an item with a key that doesn't exist.