### PR TITLE
MINOR FIX:  Fix to correct DataEquals 

### DIFF
--- a/Xeption.Tests/Xeption.Tests.csproj
+++ b/Xeption.Tests/Xeption.Tests.csproj
@@ -1,30 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211109-03" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.6" />
-    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="DeepCloner" Version="0.10.3" />
+		<PackageReference Include="FluentAssertions" Version="6.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211109-03" />
+		<PackageReference Include="System.Collections" Version="4.3.0" />
+		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.6" />
+		<PackageReference Include="xunit" Version="2.4.2-pre.12" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Xeption\Xeption.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Xeption\Xeption.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Xeption.Tests/XeptionTests.Logic.cs
+++ b/Xeption.Tests/XeptionTests.Logic.cs
@@ -7,6 +7,8 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using Force.DeepCloner;
+using Tynamix.ObjectFiller;
 using Xunit;
 using ICollectionDictionary = System.Collections.IDictionary;
 
@@ -103,8 +105,10 @@ namespace Xeptions.Tests
                 key: keyName,
                 value: textRandomValidationMessage2);
 
-            Dictionary<string, List<string>> randomDictionary = new Dictionary<string, List<string>>();
-            randomDictionary.Add(keyName, new List<string> { textRandomValidationMessage1, textRandomValidationMessage2 });
+            Dictionary<string, List<string>> randomDictionary = new Dictionary<string, List<string>>
+            {
+                { keyName, new List<string> { textRandomValidationMessage1, textRandomValidationMessage2 } }
+            };
 
             Dictionary<string, List<string>> expectedDictionary =
                 randomDictionary;
@@ -117,7 +121,6 @@ namespace Xeptions.Tests
                 actualDictionary[key].Should().BeEquivalentTo(expectedDictionary[key]);
             }
         }
-
 
         [Fact]
         public void ShouldAddDataAsDictionary()
@@ -255,6 +258,61 @@ namespace Xeptions.Tests
 
             // then
             isEqual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ShouldReturnTrueIfDataFromExceptionsIsTheSame()
+        {
+            // given
+            Dictionary<string, List<string>> randomDictionary =
+                CreateRandomDictionary();
+
+            var leftDictionary = randomDictionary;
+            var rightDictionary = randomDictionary.DeepClone();
+
+            var leftXeption = new Xeption();
+            leftXeption.AddData(leftDictionary);
+
+            var rightXeption = new Xeption();
+            rightXeption.AddData(rightDictionary);
+
+
+            // when
+            bool leftIsEqualToRight = leftXeption.DataEquals(rightXeption.Data);
+            bool rightIsEqualToleft = leftXeption.DataEquals(rightXeption.Data);
+
+            // then
+            leftIsEqualToRight.Should().BeTrue();
+            rightIsEqualToleft.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ShouldReturnFalseIfDataFromExceptionsIsNotTheSame()
+        {
+            // given
+            Dictionary<string, List<string>> randomDictionary =
+                CreateRandomDictionary();
+
+            var leftDictionary = randomDictionary;
+            var rightDictionary = randomDictionary.DeepClone();
+
+            rightDictionary.Add(
+                new MnemonicString().GetValue(),
+                new List<string> { new MnemonicString().GetValue() });
+
+            var leftXeption = new Xeption();
+            leftXeption.AddData(leftDictionary);
+
+            var rightXeption = new Xeption();
+            rightXeption.AddData(rightDictionary);
+
+            // when
+            bool leftIsEqualToRight = leftXeption.DataEquals(rightXeption.Data);
+            bool rightIsEqualToleft = rightXeption.DataEquals(leftXeption.Data);
+
+            // then
+            Assert.False(leftIsEqualToRight, "Left data dictionary not matching the right.");
+            Assert.False(rightIsEqualToleft, "Right data dictionary not matching the left.");
         }
 
         [Fact]

--- a/Xeption.Tests/XeptionTests.Logic.cs
+++ b/Xeption.Tests/XeptionTests.Logic.cs
@@ -86,6 +86,40 @@ namespace Xeptions.Tests
         }
 
         [Fact]
+        public void ShouldAppendListOfKeyValuesWhenUpsertDataListIsCalledAfterAddData()
+        {
+            string keyName = "Name";
+            string textRequiredValue = "Text is required";
+            string textLengthValue = "Text must be between 2 and 25 characters";
+
+            // given
+            var xeption = new Xeption();
+
+            xeption.AddData(
+                key: keyName,
+                values: textRequiredValue);
+
+            xeption.UpsertDataList(
+                key: keyName,
+                value: textLengthValue);
+
+            Dictionary<string, List<string>> randomDictionary = new Dictionary<string, List<string>>();
+            randomDictionary.Add(keyName, new List<string> { textRequiredValue, textLengthValue });
+
+            Dictionary<string, List<string>> expectedDictionary =
+                randomDictionary;
+
+            ICollectionDictionary actualDictionary = xeption.Data;
+
+            // then
+            foreach (string key in expectedDictionary.Keys)
+            {
+                actualDictionary[key].Should().BeEquivalentTo(expectedDictionary[key]);
+            }
+        }
+
+
+        [Fact]
         public void ShouldAddDataAsDictionary()
         {
             // given

--- a/Xeption.Tests/XeptionTests.Logic.cs
+++ b/Xeption.Tests/XeptionTests.Logic.cs
@@ -89,22 +89,22 @@ namespace Xeptions.Tests
         public void ShouldAppendListOfKeyValuesWhenUpsertDataListIsCalledAfterAddData()
         {
             string keyName = "Name";
-            string textRequiredValue = "Text is required";
-            string textLengthValue = "Text must be between 2 and 25 characters";
+            string textRandomValidationMessage1 = GetRandomMessage();
+            string textRandomValidationMessage2 = GetRandomMessage();
 
             // given
             var xeption = new Xeption();
 
             xeption.AddData(
                 key: keyName,
-                values: textRequiredValue);
+                values: textRandomValidationMessage1);
 
             xeption.UpsertDataList(
                 key: keyName,
-                value: textLengthValue);
+                value: textRandomValidationMessage2);
 
             Dictionary<string, List<string>> randomDictionary = new Dictionary<string, List<string>>();
-            randomDictionary.Add(keyName, new List<string> { textRequiredValue, textLengthValue });
+            randomDictionary.Add(keyName, new List<string> { textRandomValidationMessage1, textRandomValidationMessage2 });
 
             Dictionary<string, List<string>> expectedDictionary =
                 randomDictionary;

--- a/Xeption/Xeption.cs
+++ b/Xeption/Xeption.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using FluentAssertions.Execution;
 
@@ -26,7 +27,17 @@ namespace Xeptions
         {
             if (this.Data.Contains(key))
             {
-                (this.Data[key] as List<string>)?.Add(value);
+                if(this.Data[key] is Array)
+                {
+                    List<string> valueList = (this.Data[key] as string[]).ToList();
+                    valueList.Add(value);
+                    this.Data.Remove(key);
+                    this.Data.Add(key, valueList);
+                }
+                else
+                {
+                    (this.Data[key] as List<string>)?.Add(value);
+                }
             }
             else
             {

--- a/Xeption/Xeption.cs
+++ b/Xeption/Xeption.cs
@@ -39,7 +39,7 @@ namespace Xeptions
         {
             if (this.Data.Contains(key))
             {
-                if(this.Data[key] is Array)
+                if (this.Data[key] is Array)
                 {
                     List<string> valueList = (this.Data[key] as string[]).ToList();
                     valueList.Add(value);
@@ -81,15 +81,33 @@ namespace Xeptions
 
         public bool DataEquals(IDictionary dictionary)
         {
+            if (this.Data.Count != dictionary.Count)
+            {
+                return false;
+            }
+
             foreach (DictionaryEntry entry in dictionary)
             {
                 bool isKeyNotExists = this.Data.Contains(entry.Key) is false;
+                if (isKeyNotExists)
+                {
+                    return false;
+                }
 
                 bool isDataNotSame = CompareData(
                     firstObject: this.Data[entry.Key],
                     secondObject: dictionary[entry.Key]);
 
-                if (isKeyNotExists || isDataNotSame)
+                if (isDataNotSame)
+                {
+                    return false;
+                }
+            }
+
+            foreach (DictionaryEntry entry in this.Data)
+            {
+                bool isKeyNotExists = dictionary.Contains(entry.Key) is false;
+                if (isKeyNotExists)
                 {
                     return false;
                 }


### PR DESCRIPTION
closes #9 
Minor fix to ensure data dictionaries is compared LEFT to RIGHT and RIGHT to LEFT.   
The comparison is currently only RIGHT to LEFT.

Also added a check to compare the count of the two dictionaries to return a FALSE if they don't match so that we get a faster output as the comparison would not be required then.