### PR TITLE
DataEquals function does not fail when data is different.

### DIFF
--- a/Xeption.Tests/Xeption.Tests.csproj
+++ b/Xeption.Tests/Xeption.Tests.csproj
@@ -1,30 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Nullable>disable</Nullable>
-    <IsPackable>false</IsPackable>
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<Nullable>disable</Nullable>
+		<IsPackable>false</IsPackable>
+		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220131-20" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.7" />
-    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="DeepCloner" Version="0.10.3" />
+		<PackageReference Include="FluentAssertions" Version="6.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220131-20" />
+		<PackageReference Include="System.Collections" Version="4.3.0" />
+		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.7" />
+		<PackageReference Include="xunit" Version="2.4.2-pre.12" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Xeption\Xeption.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Xeption\Xeption.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Xeption.Tests/XeptionTests.Logic.cs
+++ b/Xeption.Tests/XeptionTests.Logic.cs
@@ -7,6 +7,8 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using Force.DeepCloner;
+using Tynamix.ObjectFiller;
 using Xunit;
 using ICollectionDictionary = System.Collections.IDictionary;
 
@@ -294,6 +296,57 @@ namespace Xeptions.Tests
 
             xeption.InnerException.Should().BeEquivalentTo(exception);
             xeption.Message.Should().BeEquivalentTo(expectedMessage);
+        }
+
+        [Fact]
+        public void ShouldReturnTrueIfDataFromExceptionsIsTheSame()
+        {
+            // given
+            Dictionary<string, List<string>> randomDictionary =
+                CreateRandomDictionary();
+
+            var leftDictionary = randomDictionary;
+            var rightDictionary = randomDictionary.DeepClone();
+            var leftXeption = new Xeption();
+            leftXeption.AddData(leftDictionary);
+            var rightXeption = new Xeption();
+            rightXeption.AddData(rightDictionary);
+
+            // when
+            bool leftIsEqualToRight = leftXeption.DataEquals(rightXeption.Data);
+            bool rightIsEqualToleft = leftXeption.DataEquals(rightXeption.Data);
+
+            // then
+            leftIsEqualToRight.Should().BeTrue();
+            rightIsEqualToleft.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ShouldReturnFalseIfDataFromExceptionsIsNotTheSame()
+        {
+            // given
+            Dictionary<string, List<string>> randomDictionary =
+                CreateRandomDictionary();
+
+            var leftDictionary = randomDictionary;
+            var rightDictionary = randomDictionary.DeepClone();
+
+            rightDictionary.Add(
+                new MnemonicString().GetValue(),
+                new List<string> { new MnemonicString().GetValue() });
+
+            var leftXeption = new Xeption();
+            leftXeption.AddData(leftDictionary);
+            var rightXeption = new Xeption();
+            rightXeption.AddData(rightDictionary);
+
+            // when
+            bool leftIsEqualToRight = leftXeption.DataEquals(rightXeption.Data);
+            bool rightIsEqualToleft = rightXeption.DataEquals(leftXeption.Data);
+
+            // then
+            Assert.False(leftIsEqualToRight, "Left data dictionary not matching the right.");
+            Assert.False(rightIsEqualToleft, "Right data dictionary not matching the left.");
         }
     }
 }

--- a/Xeption/Xeption.cs
+++ b/Xeption/Xeption.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using FluentAssertions.Execution;
 
@@ -66,19 +67,38 @@ namespace Xeptions
         }
 
         public void AddData(string key, params string[] values) =>
-            this.Data.Add(key, values);
+            this.Data.Add(key, values.ToList());
 
         public bool DataEquals(IDictionary dictionary)
         {
+            if (this.Data.Count != dictionary.Count)
+            {
+                return false;
+            }
+
             foreach (DictionaryEntry entry in dictionary)
             {
                 bool isKeyNotExists = this.Data.Contains(entry.Key) is false;
+
+                if (isKeyNotExists)
+                {
+                    return false;
+                }
 
                 bool isDataNotSame = CompareData(
                     firstObject: this.Data[entry.Key],
                     secondObject: dictionary[entry.Key]);
 
-                if (isKeyNotExists || isDataNotSame)
+                if (isDataNotSame)
+                {
+                    return false;
+                }
+            }
+
+            foreach (DictionaryEntry entry in this.Data)
+            {
+                bool isKeyNotExists = dictionary.Contains(entry.Key) is false;
+                if (isKeyNotExists)
                 {
                     return false;
                 }


### PR DESCRIPTION
Closes #9

Minor fix to ensure data dictionaries is compared LEFT to RIGHT and RIGHT to LEFT.
The comparison is currently only RIGHT to LEFT.

Also added a check to compare the count of the two dictionaries to return a FALSE if they don't match so that we get a faster output as the comparison would not be required then.