### PR TITLE
FOUNDATIONS: Introduce Should().BeEquivalentTo(...)

### DIFF
--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -65,5 +65,17 @@ namespace Xeptions.Tests
             // when then
             actualException.Should().BeEquivalentTo(expectedException);
         }
+
+        [Fact]
+        public void BeEquivalentToShouldPassIfInnerExceptionMessagesMatch()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            var expectedException = new Xeption(message: randomMessage);
+            var actualException = new Xeption(message: GetRandomString());
+
+            // when then
+            actualException.Should().BeEquivalentTo(expectedException);
+        }
     }
 }

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -95,6 +95,10 @@ namespace Xeptions.Tests
                 key: expectedInnerExceptionDataKey,
                 values: expectedInnerExceptionDataValue);
 
+            actualInnerException.AddData(
+                key: actualInnerExceptionDataKey,
+                values: actualInnerExceptionDataValue);
+
             var expectedException = new Xeption(
                 message: exceptionMessage,
                 innerException: expectedInnerException);

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -4,6 +4,7 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
+using System;
 using FluentAssertions;
 using Xunit;
 
@@ -41,6 +42,26 @@ namespace Xeptions.Tests
             string randomMessage = GetRandomString();
             var expectedException = new Xeption(message: randomMessage);
             var actualException = new Xeption(message: randomMessage);
+
+            // when then
+            actualException.Should().BeEquivalentTo(expectedException);
+        }
+
+        [Fact]
+        public void BeEquivalentToShouldPassIfInnerExceptionsMatchOnType()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Xeption expectedInnerException = new Xeption(message: randomMessage);
+            Exception actualInnerException = new Exception(message: randomMessage);
+
+            var expectedException = new Xeption(
+                message: randomMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: randomMessage,
+                innerException: actualInnerException);
 
             // when then
             actualException.Should().BeEquivalentTo(expectedException);

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -40,7 +40,7 @@ namespace Xeptions.Tests
             // given
             string randomMessage = GetRandomString();
             var expectedException = new Xeption(message: randomMessage);
-            var actualException = new Xeption(message: GetRandomString());
+            var actualException = new Xeption(message: randomMessage);
 
             // when then
             actualException.Should().BeEquivalentTo(expectedException);

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -72,7 +72,7 @@ namespace Xeptions.Tests
             // given
             string randomMessage = GetRandomString();
             var expectedException = new Xeption(message: randomMessage);
-            var actualException = new Xeption(message: GetRandomString());
+            var actualException = new Xeption(message: randomMessage);
 
             // when then
             actualException.Should().BeEquivalentTo(expectedException);

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -5,7 +5,6 @@
 // ---------------------------------------------------------------
 
 using FluentAssertions;
-using Force.DeepCloner;
 using Xunit;
 
 namespace Xeptions.Tests
@@ -18,7 +17,7 @@ namespace Xeptions.Tests
             // given
             string randomMessage = GetRandomString();
             var expectedException = new Xeption(message: randomMessage);
-            var actualException = expectedException.DeepClone();
+            var actualException = new Xeption(message: randomMessage);
 
             // when then
             actualException.Should().BeEquivalentTo(expectedException);
@@ -30,6 +29,18 @@ namespace Xeptions.Tests
             // given
             Xeption expectedException = null;
             Xeption actualException = null;
+
+            // when then
+            actualException.Should().BeEquivalentTo(expectedException);
+        }
+
+        [Fact]
+        public void BeEquivalentToShouldPassIfExceptionMessagesMatch()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            var expectedException = new Xeption(message: randomMessage);
+            var actualException = new Xeption(message: GetRandomString());
 
             // when then
             actualException.Should().BeEquivalentTo(expectedException);

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -4,7 +4,6 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
-using System;
 using FluentAssertions;
 using Xunit;
 
@@ -53,7 +52,7 @@ namespace Xeptions.Tests
             // given
             string randomMessage = GetRandomString();
             Xeption expectedInnerException = new Xeption(message: randomMessage);
-            Exception actualInnerException = new Exception(message: randomMessage);
+            Xeption actualInnerException = new Xeption(message: randomMessage);
 
             var expectedException = new Xeption(
                 message: randomMessage,

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -110,5 +110,40 @@ namespace Xeptions.Tests
             // when then
             actualException.Should().BeEquivalentTo(expectedException);
         }
+
+        [Fact]
+        public void ShouldPassIfInnerExceptionDataMatch()
+        {
+            // given
+            string exceptionMessage = GetRandomString();
+            string randomKey = GetRandomString();
+            string randomValue = GetRandomString();
+            string expectedInnerExceptionDataKey = randomKey;
+            string expectedInnerExceptionDataValue = randomValue;
+            string actualInnerExceptionDataKey = GetRandomString();
+            string actualInnerExceptionDataValue = GetRandomString();
+
+            var expectedInnerException = new Xeption(message: exceptionMessage);
+            var actualInnerException = new Xeption(message: exceptionMessage);
+
+            expectedInnerException.AddData(
+                key: expectedInnerExceptionDataKey,
+                values: expectedInnerExceptionDataValue);
+
+            actualInnerException.AddData(
+                key: actualInnerExceptionDataKey,
+                values: actualInnerExceptionDataValue);
+
+            var expectedException = new Xeption(
+                message: exceptionMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: exceptionMessage,
+                innerException: actualInnerException);
+
+            // when then
+            actualException.Should().BeEquivalentTo(expectedException);
+        }
     }
 }

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -77,5 +77,34 @@ namespace Xeptions.Tests
             // when then
             actualException.Should().BeEquivalentTo(expectedException);
         }
+
+        [Fact]
+        public void ShouldPassIfInnerExceptionDataCountMatch()
+        {
+            // given
+            string exceptionMessage = GetRandomString();
+            string expectedInnerExceptionDataKey = GetRandomString();
+            string expectedInnerExceptionDataValue = GetRandomString();
+            string actualInnerExceptionDataKey = GetRandomString();
+            string actualInnerExceptionDataValue = GetRandomString();
+
+            var expectedInnerException = new Xeption(message: exceptionMessage);
+            var actualInnerException = new Xeption(message: exceptionMessage);
+
+            expectedInnerException.AddData(
+                key: expectedInnerExceptionDataKey,
+                values: expectedInnerExceptionDataValue);
+
+            var expectedException = new Xeption(
+                message: exceptionMessage,
+                innerException: expectedInnerException);
+
+            var actualException = new Xeption(
+                message: exceptionMessage,
+                innerException: actualInnerException);
+
+            // when then
+            actualException.Should().BeEquivalentTo(expectedException);
+        }
     }
 }

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -1,0 +1,28 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Force.DeepCloner;
+using Xunit;
+
+namespace Xeptions.Tests
+{
+    public partial class XeptionAssertionTests
+    {
+        [Fact]
+        public void BeEquivalentToShouldPassIfExceptionsMatch()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            var expectedException = new Xeption(message: randomMessage);
+
+            var actualException = expectedException.DeepClone();
+
+            // when then
+            actualException.Should().BeEquivalentTo(expectedException);
+        }
+    }
+}

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -13,13 +13,23 @@ namespace Xeptions.Tests
     public partial class XeptionAssertionTests
     {
         [Fact]
-        public void BeEquivalentToShouldPassIfExceptionsMatch()
+        public void BeEquivalentToShouldPassIfExceptionsMatchOnType()
         {
             // given
             string randomMessage = GetRandomString();
             var expectedException = new Xeption(message: randomMessage);
-
             var actualException = expectedException.DeepClone();
+
+            // when then
+            actualException.Should().BeEquivalentTo(expectedException);
+        }
+
+        [Fact]
+        public void BeEquivalentToShouldPassIfNullExceptionsMatchOnType()
+        {
+            // given
+            Xeption expectedException = null;
+            Xeption actualException = null;
 
             // when then
             actualException.Should().BeEquivalentTo(expectedException);

--- a/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
+++ b/Xeption.Tests/XeptionAssertionTests.Logic.BeEquivalentTo.cs
@@ -83,21 +83,8 @@ namespace Xeptions.Tests
         {
             // given
             string exceptionMessage = GetRandomString();
-            string expectedInnerExceptionDataKey = GetRandomString();
-            string expectedInnerExceptionDataValue = GetRandomString();
-            string actualInnerExceptionDataKey = GetRandomString();
-            string actualInnerExceptionDataValue = GetRandomString();
-
             var expectedInnerException = new Xeption(message: exceptionMessage);
             var actualInnerException = new Xeption(message: exceptionMessage);
-
-            expectedInnerException.AddData(
-                key: expectedInnerExceptionDataKey,
-                values: expectedInnerExceptionDataValue);
-
-            actualInnerException.AddData(
-                key: actualInnerExceptionDataKey,
-                values: actualInnerExceptionDataValue);
 
             var expectedException = new Xeption(
                 message: exceptionMessage,
@@ -120,8 +107,8 @@ namespace Xeptions.Tests
             string randomValue = GetRandomString();
             string expectedInnerExceptionDataKey = randomKey;
             string expectedInnerExceptionDataValue = randomValue;
-            string actualInnerExceptionDataKey = GetRandomString();
-            string actualInnerExceptionDataValue = GetRandomString();
+            string actualInnerExceptionDataKey = randomKey;
+            string actualInnerExceptionDataValue = randomValue;
 
             var expectedInnerException = new Xeption(message: exceptionMessage);
             var actualInnerException = new Xeption(message: exceptionMessage);

--- a/Xeption.Tests/XeptionAssertionTests.cs
+++ b/Xeption.Tests/XeptionAssertionTests.cs
@@ -1,0 +1,23 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using System;
+using Tynamix.ObjectFiller;
+
+namespace Xeptions.Tests
+{
+    public partial class XeptionAssertionTests
+    {
+        private static string GetRandomString() =>
+            new MnemonicString().GetValue();
+
+        internal class OtherTarget
+        {
+            public static void ThrowingExceptionMethod() =>
+                throw new Exception();
+        }
+    }
+}

--- a/Xeption/Assertions/XeptionAssertionExtensions.cs
+++ b/Xeption/Assertions/XeptionAssertionExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using FluentAssertions.Exceptions;
+
+namespace FluentAssertions
+{
+    public static class XeptionAssertionExtensions
+    {
+        public static XeptionAssertions<TException> Should<TException>(this TException actualValue)
+        where TException : Exception
+        {
+            return new XeptionAssertions<TException>(actualValue);
+        }
+    }
+}

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
+using Xeptions;
+
 namespace FluentAssertions.Exceptions
 {
     public class XeptionAssertions<TException> : ReferenceTypeAssertions<Exception, XeptionAssertions<TException>>
@@ -45,6 +47,12 @@ namespace FluentAssertions.Exceptions
                     Subject?.InnerException?.Message)
                 .Then
                 .ForCondition(subject => subject?.InnerException?.Data?.Count == expectation?.InnerException?.Data?.Count)
+                .FailWith(
+                    "inner exception data to have {0} items, but found {1}.",
+                    expectation?.InnerException?.Data?.Count,
+                    Subject?.InnerException?.Data?.Count)
+                .Then
+                .ForCondition(subject => ((Xeption)(subject?.InnerException)).DataEquals(expectation?.InnerException?.Data))
                 .FailWith(
                     "inner exception data to have {0} items, but found {1}.",
                     expectation?.InnerException?.Data?.Count,

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -44,6 +44,12 @@ namespace FluentAssertions.Exceptions
                     expectation?.InnerException?.Message,
                     Subject?.InnerException?.Message)
                 .Then
+                .ForCondition(subject => subject?.InnerException?.Data?.Count == expectation?.InnerException?.Data?.Count)
+                .FailWith(
+                    "inner exception data to have {0} items, but found {1}.",
+                    expectation?.InnerException?.Data?.Count,
+                    Subject?.InnerException?.Data?.Count)
+                .Then
                 .ClearExpectation();
 
             return new AndConstraint<XeptionAssertions<TException>>(this);

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -46,17 +46,19 @@ namespace FluentAssertions.Exceptions
                     expectation?.InnerException?.Message,
                     Subject?.InnerException?.Message)
                 .Then
-                .ForCondition(subject => subject?.InnerException?.Data?.Count == expectation?.InnerException?.Data?.Count)
+                .ForCondition(subject =>
+                    (subject?.InnerException?.Data is null && expectation?.InnerException?.Data is null) ||
+                        (subject?.InnerException?.Data?.Count == expectation?.InnerException?.Data?.Count))
                 .FailWith(
                     "inner exception data to have {0} items, but found {1}.",
                     expectation?.InnerException?.Data?.Count,
                     Subject?.InnerException?.Data?.Count)
                 .Then
-                .ForCondition(subject => ((Xeption)(subject?.InnerException)).DataEquals(expectation?.InnerException?.Data))
+                .ForCondition(subject =>
+                    ((subject?.InnerException?.Data is null && expectation?.InnerException?.Data is null) ||
+                        ((Xeption)(subject?.InnerException)).DataEquals(expectation?.InnerException?.Data)))
                 .FailWith(
-                    "inner exception data to have {0} items, but found {1}.",
-                    expectation?.InnerException?.Data?.Count,
-                    Subject?.InnerException?.Data?.Count)
+                    "inner exception data to match.")
                 .Then
                 .ClearExpectation();
 

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 namespace FluentAssertions.Exceptions
 {
@@ -11,7 +12,16 @@ namespace FluentAssertions.Exceptions
 
         public AndConstraint<XeptionAssertions<TException>> BeEquivalentTo(Exception expectation, string because = "", params object[] becauseArgs)
         {
-            throw new NotImplementedException();
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected the {reason}, ")
+                .Given(() => Subject)
+                .ForCondition(subject => subject?.GetType()?.FullName == expectation?.GetType()?.FullName)
+                .FailWith("type to be {0}, but found the type to be {1}.", expectation?.GetType()?.FullName, Subject?.GetType()?.FullName)
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<XeptionAssertions<TException>>(this);
         }
 
         protected override string Identifier => "Exception";

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using FluentAssertions.Primitives;
+namespace FluentAssertions.Exceptions
+{
+    public class XeptionAssertions<TException> : ReferenceTypeAssertions<Exception, XeptionAssertions<TException>>
+    where TException : Exception
+    {
+        public XeptionAssertions(TException exception) : base(exception)
+        {
+        }
+
+        public AndConstraint<XeptionAssertions<TException>> BeEquivalentTo(Exception expectation, string because = "", params object[] becauseArgs)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override string Identifier => "Exception";
+    }
+}

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -22,6 +22,9 @@ namespace FluentAssertions.Exceptions
                 .ForCondition(subject => subject?.Message == expectation?.Message)
                 .FailWith("message to be {0}, but found {1}.", expectation?.Message, Subject?.Message)
                 .Then
+                .ForCondition(subject => subject?.InnerException.GetType()?.FullName == expectation?.InnerException.GetType()?.FullName)
+                .FailWith("inner exception type to be {0}, but found the inner exception type to be {1}.", expectation?.InnerException.GetType()?.FullName, Subject?.InnerException.GetType()?.FullName)
+                .Then
                 .ClearExpectation();
 
             return new AndConstraint<XeptionAssertions<TException>>(this);

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -25,6 +25,9 @@ namespace FluentAssertions.Exceptions
                 .ForCondition(subject => ((subject?.InnerException is null && expectation?.InnerException is null)) || (subject?.InnerException?.GetType()?.FullName == expectation?.InnerException?.GetType()?.FullName))
                 .FailWith("inner exception type to be {0}, but found the inner exception type to be {1}.", expectation?.InnerException?.GetType()?.FullName, Subject?.InnerException?.GetType()?.FullName)
                 .Then
+                .ForCondition(subject => subject?.InnerException?.Message == expectation?.InnerException?.Message)
+                .FailWith("inner exception message to be {0}, but found {1}.", expectation?.InnerException?.Message, Subject?.InnerException?.Message)
+                .Then
                 .ClearExpectation();
 
             return new AndConstraint<XeptionAssertions<TException>>(this);

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -19,6 +19,9 @@ namespace FluentAssertions.Exceptions
                 .ForCondition(subject => subject?.GetType()?.FullName == expectation?.GetType()?.FullName)
                 .FailWith("type to be {0}, but found the type to be {1}.", expectation?.GetType()?.FullName, Subject?.GetType()?.FullName)
                 .Then
+                .ForCondition(subject => subject?.Message == expectation?.Message)
+                .FailWith("message to be {0}, but found {1}.", expectation?.Message, Subject?.Message)
+                .Then
                 .ClearExpectation();
 
             return new AndConstraint<XeptionAssertions<TException>>(this);

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -10,23 +10,39 @@ namespace FluentAssertions.Exceptions
         {
         }
 
-        public AndConstraint<XeptionAssertions<TException>> BeEquivalentTo(Exception expectation, string because = "", params object[] becauseArgs)
+        public AndConstraint<XeptionAssertions<TException>> BeEquivalentTo(
+            Exception expectation,
+            string because = "",
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the {reason}, ")
                 .Given(() => Subject)
                 .ForCondition(subject => subject?.GetType()?.FullName == expectation?.GetType()?.FullName)
-                .FailWith("type to be {0}, but found the type to be {1}.", expectation?.GetType()?.FullName, Subject?.GetType()?.FullName)
+                .FailWith(
+                    "type to be {0}, but found the type to be {1}.",
+                    expectation?.GetType()?.FullName,
+                    Subject?.GetType()?.FullName)
                 .Then
                 .ForCondition(subject => subject?.Message == expectation?.Message)
-                .FailWith("message to be {0}, but found {1}.", expectation?.Message, Subject?.Message)
+                .FailWith(
+                    "message to be {0}, but found {1}.",
+                    expectation?.Message,
+                    Subject?.Message)
                 .Then
-                .ForCondition(subject => ((subject?.InnerException is null && expectation?.InnerException is null)) || (subject?.InnerException?.GetType()?.FullName == expectation?.InnerException?.GetType()?.FullName))
-                .FailWith("inner exception type to be {0}, but found the inner exception type to be {1}.", expectation?.InnerException?.GetType()?.FullName, Subject?.InnerException?.GetType()?.FullName)
+                .ForCondition(subject => ((subject?.InnerException is null && expectation?.InnerException is null)) ||
+                    (subject?.InnerException?.GetType()?.FullName == expectation?.InnerException?.GetType()?.FullName))
+                .FailWith(
+                    "inner exception type to be {0}, but found the inner exception type to be {1}.",
+                    expectation?.InnerException?.GetType()?.FullName,
+                    Subject?.InnerException?.GetType()?.FullName)
                 .Then
                 .ForCondition(subject => subject?.InnerException?.Message == expectation?.InnerException?.Message)
-                .FailWith("inner exception message to be {0}, but found {1}.", expectation?.InnerException?.Message, Subject?.InnerException?.Message)
+                .FailWith(
+                    "inner exception message to be {0}, but found {1}.",
+                    expectation?.InnerException?.Message,
+                    Subject?.InnerException?.Message)
                 .Then
                 .ClearExpectation();
 

--- a/Xeption/Assertions/XeptionAssertions.cs
+++ b/Xeption/Assertions/XeptionAssertions.cs
@@ -22,8 +22,8 @@ namespace FluentAssertions.Exceptions
                 .ForCondition(subject => subject?.Message == expectation?.Message)
                 .FailWith("message to be {0}, but found {1}.", expectation?.Message, Subject?.Message)
                 .Then
-                .ForCondition(subject => subject?.InnerException.GetType()?.FullName == expectation?.InnerException.GetType()?.FullName)
-                .FailWith("inner exception type to be {0}, but found the inner exception type to be {1}.", expectation?.InnerException.GetType()?.FullName, Subject?.InnerException.GetType()?.FullName)
+                .ForCondition(subject => ((subject?.InnerException is null && expectation?.InnerException is null)) || (subject?.InnerException?.GetType()?.FullName == expectation?.InnerException?.GetType()?.FullName))
+                .FailWith("inner exception type to be {0}, but found the inner exception type to be {1}.", expectation?.InnerException?.GetType()?.FullName, Subject?.InnerException?.GetType()?.FullName)
                 .Then
                 .ClearExpectation();
 

--- a/Xeption/Xeption.csproj
+++ b/Xeption/Xeption.csproj
@@ -46,4 +46,8 @@
 	  </None>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <Folder Include="Assertions\" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
Closes #27

```
        [Fact]
        public void BeEquivalentToShouldPassIfExceptionsMatchOnType()
        {
            // given
            string randomMessage = GetRandomString();
            var expectedException = new Xeption(message: randomMessage);
            var actualException = new Xeption(message: randomMessage);

            // when then
            actualException.Should().BeEquivalentTo(expectedException);
        }
```