### PR TITLE
FOUNDATIONS:  Validation Summary Extension

### DIFF
--- a/Xeption.Tests/XeptionExtensionTests.Logic.GetValidationSummary.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.GetValidationSummary.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
 
@@ -22,6 +23,25 @@ namespace Xeptions.Tests
 
             // when
             string actualResult = randomException.GetValidationSummary();
+
+            // then
+            actualResult.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact]
+        public void ShouldReturnValidationSummaryIfExceptionHasDataItems()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Xeption randomXeption = new Xeption(message: randomMessage);
+            randomXeption.Data.Add("Error1", new List<string> { "Error message 1" });
+            randomXeption.Data.Add("Error2", new List<string> { "Error message 2", "Error message 3" });
+
+            string expectedResult = $"{randomXeption.GetType().Name} Errors:  " +
+                $"Error1 => Error message 1;  Error2 => Error message 2, Error message 3;  \r\n";
+
+            // when
+            string actualResult = randomXeption.GetValidationSummary();
 
             // then
             actualResult.Should().BeEquivalentTo(expectedResult);

--- a/Xeption.Tests/XeptionExtensionTests.Logic.GetValidationSummary.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.GetValidationSummary.cs
@@ -1,0 +1,30 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Xeptions.Tests
+{
+    public partial class XeptionExtensionTests
+    {
+        [Fact]
+        public void ShouldReturnEmptyValidationSummaryIfNoDataItemsFoundOnExceptionOrInnerException()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            Exception randomException = new Exception(message: randomMessage);
+            string expectedResult = string.Empty;
+
+            // when
+            string actualResult = randomException.GetValidationSummary();
+
+            // then
+            actualResult.Should().BeEquivalentTo(expectedResult);
+        }
+    }
+}

--- a/Xeption.Tests/XeptionExtensionTests.Logic.GetValidationSummary.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.GetValidationSummary.cs
@@ -67,5 +67,36 @@ namespace Xeptions.Tests
             // then
             actualResult.Should().BeEquivalentTo(expectedResult);
         }
+
+        [Fact]
+        public void ShouldReturnValidationSummaryIfExceptionAndInnerExceptionHasDataItems()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            string randomInnerExceptionMessage = GetRandomString();
+            Xeption randomInnerXeption =
+                new Xeption(message: randomInnerExceptionMessage);
+
+            randomInnerXeption.Data.Add("Error3", new List<string> { "Error message 4" });
+            randomInnerXeption.Data.Add("Error4", new List<string> { "Error message 5", "Error message 6" });
+
+            Xeption randomXeption =
+                new Xeption(randomMessage, randomInnerXeption);
+
+            randomXeption.Data.Add("Error1", new List<string> { "Error message 1" });
+            randomXeption.Data.Add("Error2", new List<string> { "Error message 2", "Error message 3" });
+
+            string expectedResult =
+                $"{randomXeption.GetType().Name} Errors:  " +
+                $"Error1 => Error message 1;  Error2 => Error message 2, Error message 3;  \r\n" +
+                $"{randomInnerXeption.GetType().Name} Errors:  " +
+                $"Error3 => Error message 4;  Error4 => Error message 5, Error message 6;  \r\n";
+
+            // when
+            string actualResult = randomXeption.GetValidationSummary();
+
+            // then
+            actualResult.Should().BeEquivalentTo(expectedResult);
+        }
     }
 }

--- a/Xeption.Tests/XeptionExtensionTests.Logic.GetValidationSummary.cs
+++ b/Xeption.Tests/XeptionExtensionTests.Logic.GetValidationSummary.cs
@@ -46,5 +46,26 @@ namespace Xeptions.Tests
             // then
             actualResult.Should().BeEquivalentTo(expectedResult);
         }
+
+        [Fact]
+        public void ShouldReturnValidationSummaryIfInnerExceptionHasDataItems()
+        {
+            // given
+            string randomMessage = GetRandomString();
+            string randomInnerExceptionMessage = GetRandomString();
+            Xeption randomInnerXeption = new Xeption(message: randomInnerExceptionMessage);
+            randomInnerXeption.Data.Add("Error1", new List<string> { "Error message 1" });
+            randomInnerXeption.Data.Add("Error2", new List<string> { "Error message 2", "Error message 3" });
+            Xeption randomXeption = new Xeption(randomMessage, randomInnerXeption);
+
+            string expectedResult = $"{randomInnerXeption.GetType().Name} Errors:  " +
+                $"Error1 => Error message 1;  Error2 => Error message 2, Error message 3;  \r\n";
+
+            // when
+            string actualResult = randomXeption.GetValidationSummary();
+
+            // then
+            actualResult.Should().BeEquivalentTo(expectedResult);
+        }
     }
 }

--- a/Xeption.Tests/XeptionExtensionTests.cs
+++ b/Xeption.Tests/XeptionExtensionTests.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using Tynamix.ObjectFiller;
 
 namespace Xeptions.Tests
@@ -18,6 +19,13 @@ namespace Xeptions.Tests
         {
             public static void ThrowingExceptionMethod() =>
                 throw new Exception();
+        }
+
+        private static Dictionary<string, List<string>> CreateRandomDictionary()
+        {
+            var filler = new Filler<Dictionary<string, List<string>>>();
+
+            return filler.Create();
         }
     }
 }

--- a/Xeption/XeptionExtensions.cs
+++ b/Xeption/XeptionExtensions.cs
@@ -52,7 +52,7 @@ namespace Xeptions
         {
             StringBuilder validationSummary = new StringBuilder();
 
-            if (exception.Data.Count > 0)
+            if (exception != null && exception.Data.Count > 0)
             {
                 validationSummary.Append($"{exception.GetType().Name} Errors:  ");
 

--- a/Xeption/XeptionExtensions.cs
+++ b/Xeption/XeptionExtensions.cs
@@ -28,5 +28,8 @@ namespace Xeptions
                 && exception?.InnerException?.Message == otherException?.InnerException?.Message
                 && ((Xeption)(exception?.InnerException)).DataEquals(otherException?.InnerException?.Data))));
         }
+
+        public static string GetValidationSummary(this Exception exception) =>
+            throw new NotImplementedException();
     }
 }

--- a/Xeption/XeptionExtensions.cs
+++ b/Xeption/XeptionExtensions.cs
@@ -29,7 +29,15 @@ namespace Xeptions
                 && ((Xeption)(exception?.InnerException)).DataEquals(otherException?.InnerException?.Data))));
         }
 
-        public static string GetValidationSummary(this Exception exception) =>
+        public static string GetValidationSummary(this Exception exception)
+        {
+            if ((exception == null || exception.Data.Count == 0)
+                && (exception?.InnerException == null || exception.InnerException.Data.Count == 0))
+            {
+                return string.Empty;
+            }
+
             throw new NotImplementedException();
+        }
     }
 }

--- a/Xeption/XeptionExtensions.cs
+++ b/Xeption/XeptionExtensions.cs
@@ -5,6 +5,10 @@
 // ---------------------------------------------------------------
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace Xeptions
 {
@@ -37,7 +41,34 @@ namespace Xeptions
                 return string.Empty;
             }
 
-            throw new NotImplementedException();
+            StringBuilder validationSummary = new StringBuilder();
+            validationSummary.Append(GetErrorSummary(exception));
+            validationSummary.Append(GetErrorSummary(exception.InnerException));
+
+            return validationSummary.ToString();
+        }
+
+        private static string GetErrorSummary(Exception exception)
+        {
+            StringBuilder validationSummary = new StringBuilder();
+
+            if (exception.Data.Count > 0)
+            {
+                validationSummary.Append($"{exception.GetType().Name} Errors:  ");
+
+                foreach (DictionaryEntry entry in exception.Data)
+                {
+                    string errorSummary = ((List<string>)entry.Value)
+                        .Select((string value) => value)
+                        .Aggregate((string current, string next) => current + ", " + next);
+
+                    validationSummary.Append($"{entry.Key} => {errorSummary};  ");
+                }
+
+                validationSummary.AppendLine();
+            }
+
+            return validationSummary.ToString();
         }
     }
 }


### PR DESCRIPTION
Closes #44

This extension will extract a validation summary that can be used with a logging broker to provide a better exception summary that can be appended to the logs.

To make use of this, we can change the logging broker to append the summary like this:

```cs
public void LogError(Exception exception) =>
    this.logger.LogError(exception, $"{exception.Message} {exception.GetValidationSummary()}");

public void LogCritical(Exception exception) =>
    this.logger.LogCritical(exception, $"{exception.Message} {exception.GetValidationSummary()}");
```
The result will then look similar to this:
```
Student validation error occurred, fix the errors and try again.  InvalidStudentException Errors: UpdatedDate => Date is the same as Created Date, Date is not recent;
```
