### PR TITLE
Update target frameworks to include net10.0 in project files

### DIFF
--- a/Xeption.Infrastructure.Build/Xeption.Infrastructure.Build.csproj
+++ b/Xeption.Infrastructure.Build/Xeption.Infrastructure.Build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 

--- a/Xeption.Tests/Xeption.Tests.csproj
+++ b/Xeption.Tests/Xeption.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>net10.0;net9.0</TargetFrameworks>
 		<Nullable>disable</Nullable>
 		<IsPackable>false</IsPackable>
 		<ImplicitUsings>disable</ImplicitUsings>

--- a/Xeption/Xeption.csproj
+++ b/Xeption/Xeption.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net10.0;net9.0;netstandard2.0;netstandard2.1</TargetFrameworks>
 		<Authors>Hassan Habib, Christo du Toit</Authors>
 		<Company>Hassan Habib</Company>
 		<Description>Exceptional Exceptions</Description>


### PR DESCRIPTION
This pull request updates the target frameworks for several projects in the solution to add support for .NET 10.0 while maintaining compatibility with previous versions. The changes ensure that the projects can be built and tested against both .NET 10.0 and .NET 9.0 (and, where applicable, .NET Standard).

**Target framework updates:**

* Updated `Xeption/Xeption.csproj` to include `net10.0` in the `TargetFrameworks` property, so it now targets `.NET 10.0`, `.NET 9.0`, `.NET Standard 2.0`, and `.NET Standard 2.1`.
* Updated `Xeption.Infrastructure.Build/Xeption.Infrastructure.Build.csproj` to use the `TargetFrameworks` property with both `net10.0` and `net9.0`.
* Updated `Xeption.Tests/Xeption.Tests.csproj` to use the `TargetFrameworks` property with both `net10.0` and `net9.0`.